### PR TITLE
Ora2pg Install Script Retry Note

### DIFF
--- a/Hands-on lab/Before the HOL - Migrating Oracle to Azure SQL and PostgreSQL.md
+++ b/Hands-on lab/Before the HOL - Migrating Oracle to Azure SQL and PostgreSQL.md
@@ -300,6 +300,8 @@ PgAdmin greatly simplifies database administration and configuration tasks by pr
 
     ![Screenshot to show downloading the basic package.](./media/basic-package.png "Basic package download")
 
+    > **Note**: If you encounter any script execution errors, try running the script again.
+
 3. On the same Oracle link as above under the **version** section, locate the **SDK Package** installer under the **Development and Runtime - optional packages** section. Keep the zipped file in the Downloads directory.
 
     ![Screenshot to show the SDK Package download.](./media/sdk-package.png "SDK package download")

--- a/Hands-on lab/Manual-Resource-Setup.md
+++ b/Hands-on lab/Manual-Resource-Setup.md
@@ -352,6 +352,8 @@ PgAdmin greatly simplifies database administration and configuration tasks by pr
 
     ![Screenshot to show downloading the basic package.](./media/basic-package.png "Basic package download")
 
+    > **Note**: If you encounter any script execution errors, try running the script again.
+
 3. On the same Oracle link as above under the **version** section, locate the **SDK Package** installer under the **Development and Runtime - optional packages** section. Keep the zipped file in the Downloads directory.
 
     ![Screenshot to show the SDK Package download.](./media/sdk-package.png "SDK package download")


### PR DESCRIPTION
This PR adds a note to the HOL and Manual Setup Document that explains that the `install-ora2pg.ps1` script should be executed again if it fails. As the script is versioned with the lab documents, there should be no functional issues with the script.

This PR resolves #59.